### PR TITLE
Support for sklearn cross validation

### DIFF
--- a/misvm/misssvm.py
+++ b/misvm/misssvm.py
@@ -4,7 +4,7 @@ Implements MissSVM
 import numpy as np
 import scipy.sparse as sp
 from random import uniform
-
+import inspect
 from quadprog import IterativeQP, Objective
 from util import BagSplitter, spdiag, slices
 from kernel import by_name as kernel_by_name
@@ -17,7 +17,7 @@ class MissSVM(MICA):
     Semi-supervised learning applied to MI data (Zhou & Xu 2007)
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, alpha=1e4, **kwargs):
         """
         @param kernel : the desired kernel function; can be linear, quadratic,
                         polynomial, or rbf [default: linear]
@@ -35,8 +35,8 @@ class MissSVM(MICA):
                            the optimization procedure [default: 50]
         @param alpha : the softmax parameter [default: 1e4]
         """
-        self.alpha = kwargs.pop('alpha', 1e4)
-        super(MissSVM, self).__init__(*args, **kwargs)
+        self.alpha = alpha
+        super(MissSVM, self).__init__(**kwargs)
         self._bags = None
         self._sv_bags = None
         self._bag_predictions = None
@@ -170,6 +170,13 @@ class MissSVM(MICA):
             self._objective = best_svm._objective
             self._compute_separator(best_svm._K)
             self._bag_predictions = self.predict(self._bags)
+
+    def get_params(self, deep=True):
+        super_args = super(MissSVM, self).get_params()
+        args, _, _, _ = inspect.getargspec(MissSVM.__init__)
+        args.pop(0)
+        super_args.update({key: getattr(self, key, None) for key in args})
+        return super_args
 
 
 def _grad_softmin(x, alpha=1e4):

--- a/misvm/misvm.py
+++ b/misvm/misvm.py
@@ -4,7 +4,7 @@ Implements mi-SVM and MI-SVM
 import numpy as np
 from random import uniform
 from cvxopt import matrix as cvxmat, sparse
-
+import inspect
 from sil import SIL
 from svm import SVM
 from cccp import CCCP
@@ -18,7 +18,7 @@ class MISVM(SIL):
     The MI-SVM approach of Andrews, Tsochantaridis, & Hofmann (2002)
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, restarts=0, max_iters=0, **kwargs):
         """
         @param kernel : the desired kernel function; can be linear, quadratic,
                         polynomial, or rbf [default: linear]
@@ -35,9 +35,9 @@ class MISVM(SIL):
         @param max_iters : the maximum number of iterations in the outer loop of
                            the optimization procedure [default: 50]
         """
-        self.restarts = kwargs.pop('restarts', 0)
-        self.max_iters = kwargs.pop('max_iters', 50)
-        super(MISVM, self).__init__(*args, **kwargs)
+        self.restarts = restarts
+        self.max_iters = max_iters
+        super(MISVM, self).__init__(**kwargs)
 
     def fit(self, bags, y):
         """
@@ -160,6 +160,13 @@ class MISVM(SIL):
         super(SIL, self)._compute_separator(K)
         self._bag_predictions = self.predict(self._bags)
 
+    def get_params(self, deep=True):
+        super_args = super(MISVM, self).get_params()
+        args, _, _, _ = inspect.getargspec(self.__init__)
+        args.pop(0)
+        super_args.update({key: getattr(self, key, None) for key in args})
+        return super_args
+
 
 class miSVM(SIL):
     """
@@ -274,6 +281,13 @@ class miSVM(SIL):
             self._alphas = best_svm._alphas
             self._objective = best_svm._objective
             self._compute_separator(best_svm._K)
+
+    def get_params(self, deep=True):
+        super_args = super(MISVM, self).get_params()
+        args, _, _, _ = inspect.getargspec(self.__init__)
+        args.pop(0)
+        super_args.update({key: getattr(self, key, None) for key in args})
+        return super_args
 
 
 def _update_classes(x):

--- a/misvm/misvm.py
+++ b/misvm/misvm.py
@@ -41,7 +41,6 @@ class MISVM(SIL):
         self.max_iters = max_iters
         super(MISVM, self).__init__(**kwargs)
     
-    @profile
     def fit(self, bags, y):
         """
         @param bags : a sequence of n bags; each bag is an m-by-k array-like

--- a/misvm/sil.py
+++ b/misvm/sil.py
@@ -2,7 +2,7 @@
 Implements Single Instance Learning SVM
 """
 import numpy as np
-
+import inspect
 from svm import SVM
 from util import slices
 
@@ -12,7 +12,7 @@ class SIL(SVM):
     Single-Instance Learning applied to MI data
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         """
         @param kernel : the desired kernel function; can be linear, quadratic,
                         polynomial, or rbf [default: linear]
@@ -26,7 +26,7 @@ class SIL(SVM):
         @param sv_cutoff : the numerical cutoff for an example to be considered
                            a support vector [default: 1e-7]
         """
-        super(SIL, self).__init__(*args, **kwargs)
+        super(SIL, self).__init__(**kwargs)
         self._bags = None
         self._bag_predictions = None
 
@@ -57,6 +57,14 @@ class SIL(SVM):
         bags = [np.asmatrix(bag) for bag in bags]
         inst_preds = super(SIL, self).predict(np.vstack(bags))
         return _inst_to_bag_preds(inst_preds, bags)
+
+    def get_params(self, deep=True):
+        """
+        return params
+        """
+        args, _, _, _ = inspect.getargspec(super(SIL, self).__init__)
+        args.pop(0)
+        return {key: getattr(self, key, None) for key in args}
 
 
 def _inst_to_bag_preds(inst_preds, bags):

--- a/misvm/svm.py
+++ b/misvm/svm.py
@@ -6,9 +6,9 @@ import numpy as np
 from quadprog import quadprog
 from kernel import by_name as kernel_by_name
 from util import spdiag
+from sklearn.base import ClassifierMixin
 
-
-class SVM(object):
+class SVM(ClassifierMixin):
     """
     A standard supervised SVM implementation.
     """

--- a/misvm/svm.py
+++ b/misvm/svm.py
@@ -2,13 +2,13 @@
 Implements a standard SVM
 """
 import numpy as np
-
 from quadprog import quadprog
 from kernel import by_name as kernel_by_name
 from util import spdiag
-from sklearn.base import ClassifierMixin
+from sklearn.base import ClassifierMixin, BaseEstimator
 
-class SVM(ClassifierMixin):
+
+class SVM(ClassifierMixin, BaseEstimator):
     """
     A standard supervised SVM implementation.
     """


### PR DESCRIPTION
Made changes to the predictors so that they adhere to sklearn standards and thus can be used within the sklearn crossvalidation methods like gridsearchcv and randomizedsearchcv.

Also, some changes  were to MISVM.fit  so that it can work with sparse matrices. 
