### PR TITLE
BUG: Fix Python 3 compatibility

### DIFF
--- a/misvm/kernel.py
+++ b/misvm/kernel.py
@@ -117,7 +117,7 @@ def set_kernel(k, normalizer=no_norm):
     def K(X, Y):
         if type(X) == list:
             norm = lambda x: normalizer(x, k)
-            x_norm = matrix(map(norm, X))
+            x_norm = matrix(list(map(norm, X)))
             if id(X) == id(Y):
                 # Optimize for symmetric case
                 norms = x_norm.T * x_norm
@@ -134,11 +134,11 @@ def set_kernel(k, normalizer=no_norm):
                     diag = np.array([np.sum(k(x, x)) for x in X])
                     raw_kernel = upper + upper.T + spdiag(diag)
             else:
-                y_norm = matrix(map(norm, Y))
+                y_norm = matrix(list(map(norm, Y)))
                 norms = x_norm.T * y_norm
                 raw_kernel = k(vstack(X), vstack(Y))
-                lensX = map(len, X)
-                lensY = map(len, Y)
+                lensX = list(map(len, X))
+                lensY = list(map(len, Y))
                 if any(l != 1 for l in lensX):
                     raw_kernel = vstack([np.sum(raw_kernel[i:j, :], axis=0)
                                          for i, j in slices(lensX)])

--- a/misvm/mica.py
+++ b/misvm/mica.py
@@ -55,7 +55,7 @@ class MICA(SVM):
                       object containing m instances with k features
         @param y : an array-like object of length n containing -1/+1 labels
         """
-        self._bags = map(np.asmatrix, bags)
+        self._bags = list(map(np.asmatrix, bags))
         bs = BagSplitter(self._bags,
                          np.asmatrix(y).reshape((-1, 1)))
         self._X = bs.instances
@@ -235,4 +235,4 @@ def t(list_of_lists):
     Transpose a list of lists, since 'sparse'
     takes arguments in column-major order.
     """
-    return map(list, zip(*list_of_lists))
+    return list(map(list, zip(*list_of_lists)))

--- a/misvm/misssvm.py
+++ b/misvm/misssvm.py
@@ -48,7 +48,7 @@ class MissSVM(MICA):
                       object containing m instances with k features
         @param y : an array-like object of length n containing -1/+1 labels
         """
-        self._bags = map(np.asmatrix, bags)
+        self._bags = list(map(np.asmatrix, bags))
         bs = BagSplitter(self._bags,
                          np.asmatrix(y).reshape((-1, 1)))
         self._X = np.vstack([bs.pos_instances,

--- a/misvm/nsk.py
+++ b/misvm/nsk.py
@@ -44,7 +44,7 @@ class NSK(SVM):
                       object containing m instances with k features
         @param y : an array-like object of length n containing -1/+1 labels
         """
-        self._bags = map(np.asmatrix, bags)
+        self._bags = list(map(np.asmatrix, bags))
         self._y = np.asmatrix(y).reshape((-1, 1))
         if self.scale_C:
             C = self.C / float(len(self._bags))
@@ -93,5 +93,5 @@ class NSK(SVM):
             return np.zeros(len(bags))
         else:
             kernel = kernel_by_name(self.kernel, p=self.p, gamma=self.gamma)
-            K = kernel(map(np.asmatrix, bags), self._sv_bags)
+            K = kernel(list(map(np.asmatrix, bags)), self._sv_bags)
             return np.array(self._b + K * spdiag(self._sv_y) * self._sv_alphas).reshape((-1,))

--- a/misvm/sil.py
+++ b/misvm/sil.py
@@ -79,4 +79,4 @@ class SIL(SVM):
 
 def _inst_to_bag_preds(inst_preds, bags):
     return np.array([np.max(inst_preds[slice(*bidx)])
-                     for bidx in slices(map(len, bags))])
+                     for bidx in slices(list(map(len, bags)))])

--- a/misvm/smil.py
+++ b/misvm/smil.py
@@ -41,7 +41,7 @@ class sMIL(NSK):
                       object containing m instances with k features
         @param y : an array-like object of length n containing -1/+1 labels
         """
-        bs = BagSplitter(map(np.asmatrix, bags),
+        bs = BagSplitter(list(map(np.asmatrix, bags)),
                          np.asmatrix(y).reshape((-1, 1)))
         self._bags = bs.neg_inst_as_bags + bs.pos_bags
         self._y = np.matrix(np.vstack([-np.ones((bs.L_n, 1)),


### PR DESCRIPTION
For Python 3 support map() function should be explicitly converted to a list if the object that is mapped is used more than once.
In the old implementation of e.g. smil.py, bs.neg_bags evaluates the mapped input: map(np.asmatrix,bags); then this same input is evaluated by bs.pos_bags. However, because in Python 3 map() returns an iterator, this iterator object was destroyed at the first evaluation and returns an empty object at the second evaluation. There are several of these issues throughout the code, which have been resolved in this commit.