### PR TITLE
Fix a bug in MISVM __init__. Set max_iters default to 50.

### DIFF
--- a/misvm/mi_svm.py
+++ b/misvm/mi_svm.py
@@ -21,7 +21,7 @@ class MISVM(SIL):
     The MI-SVM approach of Andrews, Tsochantaridis, & Hofmann (2002)
     """
 
-    def __init__(self, restarts=0, max_iters=0, **kwargs):
+    def __init__(self, restarts=0, max_iters=50, **kwargs):
         """
         @param kernel : the desired kernel function; can be linear, quadratic,
                         polynomial, or rbf [default: linear]


### PR DESCRIPTION
The default value for max_iters is 0 while it should be 50. Leaving the value at 0 leads to the fit not running.